### PR TITLE
fix slave can't connect to master error

### DIFF
--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -51,7 +51,7 @@ export class Redis extends Construct {
         containerName: 'slave',
         containerPort: 6379,
         externalPort: 6379,
-        env: { GET_HOSTS_FROM: 'dns' },
+        env: { GET_HOSTS_FROM: 'env', REDIS_MASTER_SERVICE_HOST: this.masterHost },
         replicas: slaveReplicas,
         labels: {
           app: 'redis',


### PR DESCRIPTION
fixed #1 

As the service name is dynamic, the slave can't connect to 'redis-master' when `GET_HOSTS_FROM` set to `dns`. This PR enables the slaves to find the master correctly.

According to this:

https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/3fcb2fe644f0a2bcf4b2b59663026e9481298424/guestbook/redis-slave/run.sh#L17-L18

We need configure `REDIS_MASTER_SERVICE_HOST` for the slave.

After this fix applied,  all slaves are in sync with master.

> 8:S 12 May 15:07:19.792 # Server started, Redis version 3.0.3
> 8:S 12 May 15:07:19.792 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
> 8:S 12 May 15:07:19.793 * The server is now ready to accept connections on port 6379
> 8:S 12 May 15:07:19.793 * Connecting to MASTER demoapp-my-redis-master-service-a788b212:6379
> 8:S 12 May 15:07:19.794 * MASTER <-> SLAVE sync started
> 8:S 12 May 15:07:19.794 * Non blocking connect for SYNC fired the event.
> 8:S 12 May 15:07:19.794 * Master replied to PING, replication can continue...
> 8:S 12 May 15:07:19.794 * Partial resynchronization not possible (no cached master)
> 8:S 12 May 15:07:19.794 * Full resync from master: 14a7f1f6357516ec26ee631466eac05d8ad520c3:1
> 8:S 12 May 15:07:19.827 * MASTER <-> SLAVE sync: receiving 18 bytes from master
> 8:S 12 May 15:07:19.827 * MASTER <-> SLAVE sync: Flushing old data
> 8:S 12 May 15:07:19.827 * MASTER <-> SLAVE sync: Loading DB in memory
> 8:S 12 May 15:07:19.828 * MASTER <-> SLAVE sync: Finished with success

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
